### PR TITLE
feat: Add comprehensive DEFINES_MODULE normalization and improved pri…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-share-intent",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "use native share intent for ios and android with expo",
   "homepage": "https://github.com/achorein/expo-share-intent/",
   "repository": {


### PR DESCRIPTION
…vacy manifest handling

- Normalize DEFINES_MODULE across all Xcode targets to prevent CocoaPods merge conflicts
- Add error-resilient privacy manifest handling to prevent build failures
- Fix compatibility issues with expo-dev-menu and other pods that set DEFINES_MODULE
- Continue build process even when privacy manifest cannot be added to Xcode project

🤖 Generated with [Claude Code](https://claude.ai/code)

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Todo**

<!--
- [ ] ${{ Todo item }}
- [ ] Update README.md
-->

**Issue**

<!-- If you have a GitHub Issue -->
